### PR TITLE
Presenter Object

### DIFF
--- a/lib/toolbelt.rb
+++ b/lib/toolbelt.rb
@@ -5,6 +5,7 @@ require 'hash_validator'
 require 'toolbelt/util/option_validator'
 require 'toolbelt/service'
 require 'toolbelt/policy'
+require 'toolbelt/presenter'
 
 module Toolbelt
   class ToolbeltError < StandardError

--- a/lib/toolbelt/presenter.rb
+++ b/lib/toolbelt/presenter.rb
@@ -1,0 +1,32 @@
+module Toolbelt
+  class Presenter
+    include Util::OptionValidator
+
+    attr_reader :options
+
+    def self.all(collection)
+      collection.collect { |c| new(c) }
+    end
+
+    def self.present(options = {})
+      new(options).present
+    end
+
+    def initialize(options = {})
+      validate_options!(options)
+      @options = Hashie::Mash.new(options)
+    end
+
+    def present
+      fail Toolbelt::OverrideInSubclassError
+    end
+  end
+
+  private
+
+  def self.presents(name)
+    define_method(name) do
+      options.object
+    end
+  end
+end

--- a/spec/lib/toolbelt/presenter_spec.rb
+++ b/spec/lib/toolbelt/presenter_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe 'Toolbelt::Presenter' do
+  class DummyPresenter < Toolbelt::Presenter
+    def present
+      true
+    end
+
+    protected
+
+    def required_options
+      {
+        :object => 'required'
+      }
+    end
+  end
+
+  it_behaves_like 'an object with required options' do
+    let(:callable) { DummyPresenter.present }
+  end
+
+  context 'when interacted with on the base class' do
+    it 'raises an exception' do
+      expect { Toolbelt::Presnter.present }
+        .to raise_error { Toolbelt::OverrideInSubclassError }
+    end
+  end
+
+  describe 'when properly overriden from a subclass' do
+    subject { DummyPresenter.present(:object => 'mock') }
+    it { should eq(true) }
+  end
+end


### PR DESCRIPTION
Hey @pjkelly. I've been spending some more time on the `toolbelt-rails` implementation of presenters so I figured I'd propose the base class for now. I've borrowed a few methods from our `BasePresenter` class used in pristine and decided to name the presentation method `present`. Let me know your thoughts and I can make any updated accordingly.
